### PR TITLE
Increase state list for Feb 2021

### DIFF
--- a/static/widget.js
+++ b/static/widget.js
@@ -5,8 +5,25 @@
     var CLOSED_COOKIE = '_REPAIR_ORG_WIDGET_CLOSED_';
     var MS_PER_DAY = 86400000;
     var states = [
-        'WA', 'MA', 'NH', 'NJ', 'OK', 'VT', 'MD', 'DE',
-        'FL', 'SC', 'OR', 'MT'
+        'CT', 
+        'DE',
+        'FL', 
+        'HI',
+        'IL',
+        'KS',
+        'MA',
+        'MD', 
+        'MO',
+        'MT',
+        'NE',
+        'NJ', 
+        'NH',
+        'NY', 
+        'OK', 
+        'OR', 
+        'SC', 
+        'VT', 
+        'WA'
     ];
 
     // user-configurable options


### PR DESCRIPTION
Connecticut - HB 5255 and HB 5826 General template bills, new (to us) this week. Need support sent to Energy Committee Chair. Connecticut also has an automobile right to repair measure, HB 6216.
Delaware - HB22 - general template bill - hearing was delayed. First year they are considering the bill. Gay is point.
Florida -  S 374 ag-only and House companion H 0511
Hawaii -- 4 bills, 2 in each chamber. SB 760 (medical), SB 564 (general), HB415 (consumer products), HB 226 (general).
Kansas -- NEW! -- HB 2309 - ag only
Maryland - HB 84 and SB 412
Massachusetts - HD 260 and SD 199 - both general template, no medical. 
Missouri - HB975 - ag-only and HB 1118 - generic template. 
Montana - two bills in MT, HB 175 - generic template and a ag-only version HB 390 (officially filed now)
Nebraska - LB543 Ag only.
New Jersey - A 1482 - generic template - carry over. Trying to get more stakeholders engaged. Gay has some leads. There is also an ag-only bill - A 2906
New Hampshire -- HB449 - Appliances only
New York - S04104 -- as well an ag-only S149 also filed
Oklahoma - HB1011 - general template
Oregon - HB 2698 - general template, no ag. Hearing this week. 
South Carolina - H 3500 - ag-only plus a nonbinding resolution in favor H 3577.
Vermont - H.58 - ag only bill, and a new senate companion S.67. We need farmers with stories. 
Washington - HB 1212

Plus Illinois coming.